### PR TITLE
fix packaging issue

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,9 @@
 .vscode/**
 .vscode-test/**
-node_modules/**
 out/test/**
 out/**/*.map
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
 tslint.json
+src


### PR DESCRIPTION
vsce uses this file to decide which files to be excluded from the vsix package, the node_modules folder needs to be included.